### PR TITLE
fix(auth): fall back to interactive login when token refresh fails

### DIFF
--- a/gdrive_cli/drive_service.py
+++ b/gdrive_cli/drive_service.py
@@ -20,6 +20,7 @@ import pickle
 from pathlib import Path
 from typing import Any
 
+from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
@@ -57,16 +58,26 @@ class DriveService:
         # If no valid credentials, authenticate
         if not creds or not creds.valid:
             if creds and creds.expired and creds.refresh_token:
-                creds.refresh(Request())
+                try:
+                    creds.refresh(Request())
+                except RefreshError:
+                    # The stored refresh token is no longer valid (e.g. revoked,
+                    # expired, or the OAuth consent screen is in testing mode).
+                    # Fall back to a fresh interactive login.
+                    creds = self._run_flow()
             else:
-                flow = InstalledAppFlow.from_client_secrets_file(self.credentials_path, SCOPES)
-                creds = flow.run_local_server(port=0)
+                creds = self._run_flow()
 
             # Save credentials for next time
             with open(self.token_path, "wb") as token:
                 pickle.dump(creds, token)
 
         return build("drive", "v3", credentials=creds)
+
+    def _run_flow(self):
+        """Run the interactive OAuth flow and return fresh credentials."""
+        flow = InstalledAppFlow.from_client_secrets_file(self.credentials_path, SCOPES)
+        return flow.run_local_server(port=0)
 
     def list_files(
         self,

--- a/tests/test_drive_service.py
+++ b/tests/test_drive_service.py
@@ -122,6 +122,44 @@ class TestDriveServiceAuthenticate:
         mock_build.assert_called_once()
         assert service.service is not None
 
+    @patch("gdrive_cli.drive_service.build")
+    @patch("gdrive_cli.drive_service.InstalledAppFlow")
+    @patch("gdrive_cli.drive_service.Request")
+    @patch("gdrive_cli.drive_service.pickle")
+    @patch("gdrive_cli.drive_service.Path")
+    def test_authenticate_refresh_failure_falls_back_to_flow(
+        self, mock_path, mock_pickle, mock_request, mock_flow, mock_build
+    ):
+        """Test that a failed token refresh (invalid_grant) re-runs the OAuth flow."""
+        from google.auth.exceptions import RefreshError
+
+        # Token exists
+        mock_path.return_value.exists.return_value = True
+
+        # Mock expired credentials whose refresh token is no longer valid
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.expired = True
+        mock_creds.refresh_token = "stale_refresh_token"
+        mock_creds.refresh.side_effect = RefreshError("invalid_grant: Bad Request")
+        mock_pickle.load.return_value = mock_creds
+
+        # Fresh credentials returned by the interactive flow
+        new_creds = MagicMock()
+        new_creds.valid = True
+        mock_flow.from_client_secrets_file.return_value.run_local_server.return_value = new_creds
+
+        mock_build.return_value = MagicMock()
+
+        with patch("builtins.open", mock_open()):
+            service = DriveService(credentials_path="creds.json")
+
+        # Refresh was attempted, failed, and the flow was used to re-authenticate
+        mock_creds.refresh.assert_called_once()
+        mock_flow.from_client_secrets_file.assert_called_once()
+        mock_build.assert_called_once_with("drive", "v3", credentials=new_creds)
+        assert service.service is not None
+
 
 class TestDriveServiceListFiles:
     """Tests for the list_files method."""


### PR DESCRIPTION
## Problem

Running any command with a stored `token.pickle` whose refresh token was no longer valid (revoked, expired, or issued while the OAuth consent screen is in *testing* mode) crashed with a raw:

```
Error: ('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})
```

`_authenticate()` called `creds.refresh(Request())` with no error handling, so `google.auth.exceptions.RefreshError` propagated all the way up instead of recovering.

## Fix

- Catch `RefreshError` around `creds.refresh()` and fall back to a fresh interactive OAuth login.
- Extract the flow into a `_run_flow()` helper so the no-token and failed-refresh paths share it.

A stale/revoked token now silently triggers re-authentication instead of erroring out.

## Tests

Added `test_authenticate_refresh_failure_falls_back_to_flow`, which mocks an expired credential whose `refresh()` raises `RefreshError` and asserts the OAuth flow re-runs and the service is built with the fresh credentials. Written test-first (red → green). Full suite: 113 passed, 97.7% coverage.